### PR TITLE
move where people are dropped from dataset

### DIFF
--- a/analysis/01_eth_cr_analysis_dataset.do
+++ b/analysis/01_eth_cr_analysis_dataset.do
@@ -783,21 +783,19 @@ drop `r(varlist)'
 
 /* APPLY INCLUSION/EXCLUIONS==================================================*/ 
 
-
+count
 
 noi di "DROP AGE >110:"
 drop if age > 110 & age != .
 
+count
+
 noi di "DROP IF DIED BEFORE INDEX"
 drop if onsdeath_date <= date("$indexdate", "DMY")
+drop if cpnsdeath_date <= date("$indexdate", "DMY")
 
-noi di "DROP IF OUTCOMES OCCUR BEFORE INDEX"
+count 
 
-local p"suspected confirmed tested positivetest ae icu ventilation cpnsdeath onsdeath onscoviddeath ons_noncoviddeath" 
-foreach i of local p {
-	cap drop if `i'_date <= date("$indexdate", "DMY") 
-}
-	
 ***************
 *  Save data  *
 ***************
@@ -808,8 +806,10 @@ save "$Tempdir/analysis_dataset.dta", replace
 
 foreach i of global outcomes {
 	use "$Tempdir/analysis_dataset.dta", clear
+	
+	drop if `i'_date <= date("$indexdate", "DMY") 
 
-	stset stime_`i', fail(`i') 				///
+	stset stime_`i', fail(`i') 				///	
 	id(patient_id) enter(enter_date) origin(enter_date)
 	save "$Tempdir/analysis_dataset_STSET_`i'.dta", replace
 }	


### PR DESCRIPTION
This is a fix for creating the analysis dataset.
Previously it dropped people who'd had any outcome prior to indexdate.
This now only drops them in the dataset specific to each outcome rather than the general analysis dataset.

I think for ethnicity, the first thing we want to describe is the ethnic distribution of the TPP population alive at index date (within age range).

And then in the datasets for each outcome of interest, exclude people who had the outcome prior to index.